### PR TITLE
Remove outdated os.errno import

### DIFF
--- a/fanficdownload.py
+++ b/fanficdownload.py
@@ -10,6 +10,7 @@ from tempfile import mkdtemp
 from shutil import rmtree
 import socket
 from time import strftime, localtime
+import errno
 from errno import ENOENT
 
 from multiprocessing import Pool

--- a/fanficdownload.py
+++ b/fanficdownload.py
@@ -1,5 +1,5 @@
 from fanficfare import geturls
-from os import listdir, remove, rename, utime, errno, devnull
+from os import listdir, remove, rename, utime, devnull
 from os.path import isfile, join
 from subprocess import check_output, STDOUT, call, PIPE
 import logging


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.7.html#changes-in-the-python-api

From Python 3.7 onward, `os.errno` was removed from the standard library in favour of `errno`.