### PR TITLE
refactored to not use apprise config scheme and pass uri directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ ENV/
 
 # Workspace
 .code-workspace
+
+#scratch folder for testing
+scratch/

--- a/root/app/notification_base.py
+++ b/root/app/notification_base.py
@@ -67,18 +67,18 @@ class NotificationBase:
                 "Notification configuration is missing in the TOML file."
             )
             return
-        apprise_config_path = notification_config.get("apprise_config_path")
-        if not apprise_config_path:
+        apprise_uri = notification_config.get("apprise_uri")
+        if not apprise_uri:
             ff_logging.log_failure(
-                "Apprise configuration path is missing in the TOML file."
+                "Apprise configuration URI is missing in the TOML file."
             )
             return
 
         self.apprise = apprise.Apprise()
-        added = self.apprise.add(apprise_config_path)
+        added = self.apprise.add(apprise_uri)
         if not added:
             ff_logging.log_failure(
-                f"Failed to load Apprise configuration from {apprise_config_path}"
+                f"Failed to load Apprise notification URI from {apprise_uri}"
             )
             return
         self.enabled = True

--- a/root/app/notification_base_test.py
+++ b/root/app/notification_base_test.py
@@ -13,7 +13,7 @@ class TestNotificationBase(unittest.TestCase):
         patcher_toml_load = patch(
             "tomllib.load",
             return_value={
-                "notification": {"apprise_config_path": "path/to/apprise.yaml"}
+                "notifications": {"apprise_uri": "mock://apprise_uri"}
             },
         )
         patcher_apprise = patch("notification_base.apprise.Apprise")
@@ -26,7 +26,7 @@ class TestNotificationBase(unittest.TestCase):
         self.addCleanup(patcher_toml_load.stop)
         self.addCleanup(patcher_apprise.stop)
 
-        self.notification = NotificationBase("fake_path")
+        self.notification = NotificationBase("fake_path", sleep_time=10)
 
     def test_initialization(self):
         # Test initialization and config loading
@@ -36,7 +36,7 @@ class TestNotificationBase(unittest.TestCase):
         self.assertTrue(self.notification.enabled)
         self.assertEqual(
             self.notification.config,
-            {"notification": {"apprise_config_path": "path/to/apprise.yaml"}},
+            {"notifications": {"apprise_uri": "mock://apprise_uri"}},
         )
 
     def test_send_notification(self):

--- a/root/config.default/config.toml
+++ b/root/config.default/config.toml
@@ -13,4 +13,4 @@ default_ini = ""
 personal_ini = ""
 
 [notifications]
-apprise_config_path = "/config/apprise.yaml"
+apprise_uri = "dbus://"


### PR DESCRIPTION
the notifications work for me now. I haven't tested thoroughly, but I can confirm discord webhooks and linux desktop notifications work on my system. 