### PR TITLE
Refactor Dockerfile; fix Calibre install to respect version choice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,74 @@ LABEL build_version="FFDL-Auto version:- ${VERSION} Calibre: ${CALIBRE_RELEASE}"
 
 ENV PUID="911" \
     PGID="911" \
-    VERBOSE=false
+    VERBOSE=false \
+    DEBIAN_FRONTEND=noninteractive
+
 
 RUN set -ex && \
-    apt-get update && \
-    apt-get install -y --upgrade \
-    bash \
-    ca-certificates \
-    gcc \
-    wget \
-    xdg-utils \
-    curl \
-    dbus \
-    jq \
-    python3
+    echo "**** install dependencies ****" && \
+      apt-get update && \
+      apt-get install -y --upgrade --no-install-recommends \
+        bash \
+        ca-certificates \
+        gcc \
+        wget \
+        xdg-utils \
+        curl \
+        dbus \
+        jq \
+        python3 \
+        fcitx-rime \
+        fonts-wqy-microhei \
+        libnss3 \
+        libopengl0 \
+        libxkbcommon-x11-0 \
+        libxcb-cursor0 \
+        libxcb-icccm4 \
+        libxcb-image0 \
+        libxcb-keysyms1 \
+        libxcb-randr0 \
+        libxcb-render-util0 \
+        libxcb-xinerama0 \
+        poppler-utils \
+        python3-xdg \
+        ttf-wqy-zenhei \
+        xz-utils && \
+    echo "**** cleaning up ****" && \
+      apt-get clean && \
+      rm -rf \
+        /tmp/* \
+        /var/lib/apt/lists/* \
+        /var/tmp/*
+	
+RUN echo "**** install calibre ****" && \
+      mkdir -p \
+        /opt/calibre && \
+      if [ -z ${CALIBRE_RELEASE+x} ]; then \
+        CALIBRE_RELEASE=$(curl -sX GET "https://api.github.com/repos/kovidgoyal/calibre/releases/latest" \
+        | jq -r .tag_name); \
+      fi && \
+      CALIBRE_VERSION="$(echo ${CALIBRE_RELEASE} | cut -c2-)" && \
+      CALIBRE_URL="https://download.calibre-ebook.com/${CALIBRE_VERSION}/calibre-${CALIBRE_VERSION}-x86_64.txz" && \
+      curl -o \
+        /tmp/calibre-tarball.txz -L \
+        "$CALIBRE_URL" && \
+      tar xvf /tmp/calibre-tarball.txz -C \
+        /opt/calibre && \
+      /opt/calibre/calibre_postinstall && \
+      dbus-uuidgen > /etc/machine-id && \
+      rm -rf /tmp/calibre-tarball.txz
+
+COPY requirements.txt /tmp/
+RUN echo "*** Install Other Python Packages ***" && \
+      python3 -m pip install --no-cache-dir -r /tmp/requirements.txt && \
+    echo "*** Install FFF ***" && \
+    echo "FF Using Test Release" && \
+      python3 -m pip install --no-cache-dir -i https://test.pypi.org/simple/ FanFicFare && \
+    echo "**** cleaning up ****" && \
+      rm -rf /tmp/*
+
+COPY root/ /
 
 RUN addgroup --gid "$PGID" abc && \
     adduser \
@@ -30,34 +84,12 @@ RUN addgroup --gid "$PGID" abc && \
     --uid "$PUID" \
     --ingroup abc \
     --shell /bin/bash \
-    abc 
-
-RUN echo "**** install calibre ****" && \
-    apt-get install -y calibre && \
-    dbus-uuidgen > /etc/machine-id
-
-
-RUN echo "*** Install Other Python Packages ***"
-COPY requirements.txt /tmp/
-RUN python3 -m pip install --no-cache-dir -r /tmp/requirements.txt
-
-RUN echo "*** Install FFF ***" && \
-    echo "FF Using Test Release"; \
-    python3 -m pip install --no-cache-dir -i https://test.pypi.org/simple/ FanFicFare
-
-RUN echo "**** cleanup ****" && \
-    rm -rf \
-    /tmp/* \
-    /var/lib/apt/lists/* \
-    /var/tmp/*
-
-COPY root/ /
-
-RUN chmod -R +777 /app/
+    abc && \
+    chmod -R +777 /app/
 
 VOLUME /config
 
 WORKDIR /config
 
 #ENTRYPOINT ["/init"]
-CMD sh -c 'if [ "$VERBOSE" = "true" ]; then python -u /app/fanficdownload.py --config="/config/config.toml" --verbose; else python -u /app/fanficdownload.py --config="/config/config.toml"; fi'
+CMD ["/app/entrypoint.sh"]

--- a/root/app/entrypoint.sh
+++ b/root/app/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Check the VERBOSE environment variable and prepare arguments
+if [ "$VERBOSE" = "true" ]; then
+  exec python -u /app/fanficdownload.py --config="/config/config.toml" --verbose
+else
+  exec python -u /app/fanficdownload.py --config="/config/config.toml"
+fi


### PR DESCRIPTION
Borrowing heavily from https://github.com/linuxserver/docker-calibre/blob/5b6038040ad88699c20323e1094370f71710e92c/Dockerfile, this sets the Dockerfile to install the latest version of Calibre.

At the moment, it's just installing from the Debian Bookworm APT source so [it's stuck on Calibre 6.13](https://packages.debian.org/bookworm/calibre). This uses the tarball from Calibre and installs it manually. Another plus to doing it this way is that it shaves a full 1GB off of the image size 🤯 

```
mrtyton/automated-ffdl                           latest        ec4d6c15c38d   3 days ago       2.09GB
aaroncarson/autofff                              latest        7b2c6a5e33bb   11 minutes ago   1.15GB
```