### PR TITLE
fix: remove --replace command from calibredb call

### DIFF
--- a/root/app/calibre_integration/calibredb_utils.py
+++ b/root/app/calibre_integration/calibredb_utils.py
@@ -330,7 +330,6 @@ class CalibreDBClient:
             # Let's check the CLI usage. `calibredb add_format [options] id file`
             full_command_args = [
                 "add_format",
-                "--replace",
                 str(fanfic.calibre_id),
                 file_to_add,
             ]

--- a/root/tests/unit/test_calibredb_utils.py
+++ b/root/tests/unit/test_calibredb_utils.py
@@ -539,7 +539,7 @@ class TestCalibreDBClient(unittest.TestCase):
             call_args = mock_execute.call_args
             command = call_args[0][0]
             self.assertIn("add_format", command)
-            self.assertIn("--replace", command)
+            self.assertNotIn("--replace", command)
             # fanfic object is passed as second arg
             self.assertEqual(call_args[0][1], mock_fanfic)
 


### PR DESCRIPTION
The --replace flag is no longer supported in calibredb and causes ebook updates to fail.

Removing it from calibre_integration/calibredb_utils.py (line 333) resolves the issue.